### PR TITLE
SRVLOGIC-281: Move upstream-sync CI to kie-ci repository

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -1,0 +1,20 @@
+name: Sync main-apache branch
+
+env:
+  GITHUB_TOKEN: ${{ secrets.APACHE_SYNC_MIDSTREAM_TOKEN }}
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # every day at midnight
+  workflow_dispatch:
+
+jobs:
+  sync-main-apache:
+    name: Sync main-apache branch
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Sync main-apache branch with upstream/main
+        uses: kiegroup/kie-ci/.ci/actions/upstream-sync@main
+        with:
+          upstream_remote: https://github.com/apache/incubator-kie-tools.git


### PR DESCRIPTION
**Jira:** https://issues.redhat.com/browse/SRVLOGIC-281

**Description:**
Move upstream-sync CI to kie-ci repository to make it reusable from other midstream repositories

**Required PR:** 
https://github.com/kiegroup/kie-ci/pull/1554
