### PR TITLE
SRVLOGIC-282: Move main-sync CI to kie-ci repository

### DIFF
--- a/.github/workflows/main-sync.yml
+++ b/.github/workflows/main-sync.yml
@@ -1,0 +1,21 @@
+name: Sync main branch
+
+env:
+  GITHUB_TOKEN: ${{ secrets.APACHE_SYNC_MIDSTREAM_TOKEN }}
+
+on:
+  schedule:
+    - cron: "0 1 * * 0"
+  workflow_dispatch:
+
+jobs:
+  sync-main:
+    name: Sync main branch
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Create a PR to sync main branch with main-apache
+        uses: kiegroup/kie-ci/.ci/actions/main-sync@main
+        with:
+          main_sync_workflow_exclude_paths: ${{ vars.MAIN_SYNC_WORKFLOW_EXCLUDE_PATHS }}
+          main_sync_workflow_pr_reviewers: ${{ vars.MAIN_SYNC_WORKFLOW_PR_REVIEWERS }}


### PR DESCRIPTION
**Jira:** https://issues.redhat.com/browse/SRVLOGIC-282

**Description:**
Move main-sync CI to kie-ci repository to make it reusable from other midstream repositories

**Required PRs:** 
- https://github.com/kiegroup/kie-ci/pull/1552
- https://github.com/kiegroup/kie-tools/pull/5

**Example PR:**
An example of a Sync PR is here: https://github.com/fantonangeli/incubator-kie-kogito-examples/pull/2
