### PR TITLE
KOGITO-8611 Added Fix for Copy/Cut/Paste Shortcuts not working in Mac

### DIFF
--- a/packages/boxed-expression-component/src/selection/BeeTableSelectionContext.tsx
+++ b/packages/boxed-expression-component/src/selection/BeeTableSelectionContext.tsx
@@ -286,9 +286,7 @@ export function BeeTableSelectionContextProvider({ children }: React.PropsWithCh
       return;
     }
 
-    const clipboardMatrix = clipboardValue
-      .split(CLIPBOARD_TO_TEXT_ROW_SEPARATOR)
-      .map((r) => r.split(CLIPBOARD_COLUMN_SEPARATOR));
+    const clipboardMatrix = clipboardValue;
 
     const { startRow, endRow, startColumn, endColumn } = getSelectionIterationBoundaries(selectionRef.current);
 
@@ -300,7 +298,7 @@ export function BeeTableSelectionContextProvider({ children }: React.PropsWithCh
         refs.current
           ?.get(r)
           ?.get(c)
-          ?.forEach((e) => e.setValue?.(clipboardMatrix[r - startRow]?.[c - startColumn]));
+          ?.forEach((e) => e.setValue?.(clipboardMatrix));
       }
     }
 

--- a/packages/feel-input-component/src/FeelInput.tsx
+++ b/packages/feel-input-component/src/FeelInput.tsx
@@ -348,6 +348,50 @@ export const FeelInput = React.forwardRef<FeelInputRef, FeelInputProps>(
         });
 
         editor.onKeyDown((e) => {
+          if (e?.metaKey && e?.code == "KeyC") {
+            let selection = editor.getSelection();
+            let selectedtext = selection && editor.getModel()?.getValueInRange(selection);
+            selectedtext && navigator.clipboard.writeText(selectedtext);
+          }
+
+          if (e?.metaKey && e?.code == "KeyX") {
+            let selection = editor.getSelection();
+            if (selection) {
+              let selectedtext = editor.getModel()?.getValueInRange(selection);
+              selectedtext && navigator.clipboard.writeText(selectedtext);
+
+              const range = new Monaco.Range(
+                selection.startLineNumber,
+                selection.startColumn,
+                selection.endLineNumber,
+                selection.endColumn
+              );
+              const textEdits = [{ range: range, text: "" }];
+              editor.executeEdits("paste", textEdits);
+            }
+          }
+
+          if (e?.metaKey && e?.code == "KeyV") {
+            navigator.clipboard
+              .readText()
+              .then((text) => {
+                const selection = editor.getSelection();
+
+                if (selection) {
+                  const range = new Monaco.Range(
+                    selection.startLineNumber,
+                    selection.startColumn,
+                    selection.endLineNumber,
+                    selection.endColumn
+                  );
+                  const textEdits = [{ range, text }];
+                  editor.executeEdits("paste", textEdits);
+                }
+              })
+              .catch((error) => {
+                console.error("Failed to read text from clipboard:", error);
+              });
+          }
           onKeyDown?.(e, editor.getValue());
         });
 


### PR DESCRIPTION
Hi Team,

This pull request addresses an issue where the standard copy, cut, and paste keyboard shortcuts (⌘C, ⌘X, ⌘V) don't work within the DMN Editor extension for VSCode on macOS.

The changes in this PR resolve this functionality gap, ensuring a consistent user experience for clipboard interactions within the DMN editor.

**Following is the summary of changes done in this PR:**
1. Enables Shortcut binds (⌘C, ⌘X, ⌘V) for cut, copy, and paste actions.
2. Enables selected content to be cut, copy or pasted.
3. Supports copying selected text, including content that spans multiple lines. This addresses the current issue where only text before newlines is copied.

Manual testing confirmed successful clipboard functionality after the changes. 
![ezgif-7-0cd2b36f07](https://github.com/kiegroup/kie-tools/assets/168902566/31fe4fcc-ddf1-4134-afa3-51ee65209a94)

Please review this pull request and provide any feedback.

More details on the issue can be found in this Jira Ticket. https://issues.redhat.com/browse/KOGITO-8611

Regards,
Kannan S
