### PR TITLE
No-issue: fix non readable pom

### DIFF
--- a/packages/maven-base/pom.xml
+++ b/packages/maven-base/pom.xml
@@ -27,6 +27,7 @@
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
     <version>32</version>
+    <relativePath />
   </parent>
 
   <groupId>org.kie</groupId>


### PR DESCRIPTION
**Error:**
[ERROR]   The project org.kie.tools:dmn-testing-models:${revision} (/home/fantonan/NotBackedUp/repos/kie-tools/packages/dmn-testing-models/pom.xml) has 1 error
[ERROR]     Non-readable POM /home/fantonan/NotBackedUp/repos/kie-tools/packages/dmn-testing-models/node_modules/@kie-tools/pom.xml: /home/fantonan/NotBackedUp/repos/kie-tools/packages/dmn-testing-models/node_modules/@kie-tools/pom.xml (No such file or directory) @ /home/fantonan/NotBackedUp/repos/kie-tools/packages/dmn-testing-models/node_modules/@kie-tools/pom.xml

**Solution:**
<relativePath /> in maven-base: Maven will first look for the parent POM in the local filesystem, and then it will fallback to Maven Central and fetch the parent POM from there. 
Without this maven has problems following the symbolic link `./node_modules/@kie-tools/maven-base/pom.xml`.