### PR TITLE
kie-issues#1207: serverless-workflow-diagram-editor get ECONNREFUSED on bootstrap with a proxy

### DIFF
--- a/packages/serverless-workflow-diagram-editor/package.json
+++ b/packages/serverless-workflow-diagram-editor/package.json
@@ -33,6 +33,7 @@
     "adm-zip": "^0.5.10",
     "cpr": "^3.0.1",
     "mvn-artifact-download": "6.1.1",
+    "proxy-agent": "^6.4.0",
     "rimraf": "^3.0.2",
     "run-script-os": "^1.1.6",
     "symlink-dir": "^5.0.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,18 +244,6 @@ importers:
         specifier: ^1.1.6
         version: 1.1.6
 
-  examples/dmn-quarkus-example:
-    devDependencies:
-      "@kie-tools/maven-config-setup-helper":
-        specifier: workspace:*
-        version: link:../../packages/maven-config-setup-helper
-      "@kie-tools/root-env":
-        specifier: workspace:*
-        version: link:../../packages/root-env
-      run-script-os:
-        specifier: ^1.1.6
-        version: 1.1.6
-
   examples/drools-process-usertasks-quarkus-example:
     dependencies:
       "@kie-tools/jbpm-quarkus-devui":
@@ -10226,6 +10214,9 @@ importers:
       mvn-artifact-download:
         specifier: 6.1.1
         version: 6.1.1
+      proxy-agent:
+        specifier: ^6.4.0
+        version: 6.4.0
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -29054,6 +29045,11 @@ packages:
     engines: { node: ">= 10" }
     dev: true
 
+  /@tootallnate/quickjs-emscripten@0.23.0:
+    resolution:
+      { integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA== }
+    dev: true
+
   /@trysound/sax@0.2.0:
     resolution:
       { integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA== }
@@ -31441,6 +31437,16 @@ packages:
       - supports-color
     dev: true
 
+  /agent-base@7.1.1:
+    resolution:
+      { integrity: sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA== }
+    engines: { node: ">= 14" }
+    dependencies:
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /agentkeepalive@4.1.4:
     resolution:
       { integrity: sha512-+V/rGa3EuU74H6wR04plBb7Ks10FbtUQgRj/FQOG7uUIEuaINI+AiqJR1k6t3SVNs7o7ZjIdus6706qqzVq8jQ== }
@@ -32290,6 +32296,14 @@ packages:
     engines: { node: ">=0.10.0" }
     dev: true
 
+  /ast-types@0.13.4:
+    resolution:
+      { integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w== }
+    engines: { node: ">=4" }
+    dependencies:
+      tslib: 2.6.2
+    dev: true
+
   /ast-types@0.14.2:
     resolution:
       { integrity: sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA== }
@@ -33010,6 +33024,12 @@ packages:
     engines: { node: ">= 0.8" }
     dependencies:
       safe-buffer: 5.1.2
+    dev: true
+
+  /basic-ftp@5.0.5:
+    resolution:
+      { integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg== }
+    engines: { node: ">=10.0.0" }
     dev: true
 
   /batch@0.6.1:
@@ -35688,6 +35708,12 @@ packages:
       { integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A== }
     engines: { node: ">= 12" }
 
+  /data-uri-to-buffer@6.0.2:
+    resolution:
+      { integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw== }
+    engines: { node: ">= 14" }
+    dev: true
+
   /data-urls@2.0.0:
     resolution:
       { integrity: sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ== }
@@ -36153,6 +36179,16 @@ packages:
   /defu@6.1.2:
     resolution:
       { integrity: sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ== }
+    dev: true
+
+  /degenerator@5.0.1:
+    resolution:
+      { integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ== }
+    engines: { node: ">= 14" }
+    dependencies:
+      ast-types: 0.13.4
+      escodegen: 2.1.0
+      esprima: 4.0.1
     dev: true
 
   /del@6.1.1:
@@ -38992,6 +39028,16 @@ packages:
       jsonfile: 6.1.0
       universalify: 2.0.0
 
+  /fs-extra@11.2.0:
+    resolution:
+      { integrity: sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw== }
+    engines: { node: ">=14.14" }
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.1.0
+      universalify: 2.0.0
+    dev: true
+
   /fs-extra@7.0.1:
     resolution:
       { integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw== }
@@ -39212,6 +39258,19 @@ packages:
       call-bind: 1.0.7
       es-errors: 1.3.0
       get-intrinsic: 1.2.4
+    dev: true
+
+  /get-uri@6.0.3:
+    resolution:
+      { integrity: sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw== }
+    engines: { node: ">= 14" }
+    dependencies:
+      basic-ftp: 5.0.5
+      data-uri-to-buffer: 6.0.2
+      debug: 4.3.4
+      fs-extra: 11.2.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /get-user-locale@1.5.1:
@@ -40082,6 +40141,17 @@ packages:
       - supports-color
     dev: true
 
+  /http-proxy-agent@7.0.2:
+    resolution:
+      { integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig== }
+    engines: { node: ">= 14" }
+    dependencies:
+      agent-base: 7.1.0
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /http-proxy-middleware@2.0.6(@types/express@4.17.17):
     resolution:
       { integrity: sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw== }
@@ -40215,6 +40285,17 @@ packages:
   /https-proxy-agent@7.0.2:
     resolution:
       { integrity: sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA== }
+    engines: { node: ">= 14" }
+    dependencies:
+      agent-base: 7.1.0
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /https-proxy-agent@7.0.4:
+    resolution:
+      { integrity: sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg== }
     engines: { node: ">= 14" }
     dependencies:
       agent-base: 7.1.0
@@ -43373,6 +43454,12 @@ packages:
     engines: { node: ">=12" }
     dev: true
 
+  /lru-cache@7.18.3:
+    resolution:
+      { integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA== }
+    engines: { node: ">=12" }
+    dev: true
+
   /lz-string@1.5.0:
     resolution:
       { integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ== }
@@ -44414,6 +44501,12 @@ packages:
       { integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw== }
     dev: true
 
+  /netmask@2.0.2:
+    resolution:
+      { integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg== }
+    engines: { node: ">= 0.4.0" }
+    dev: true
+
   /nice-napi@1.0.2:
     resolution:
       { integrity: sha512-px/KnJAJZf5RuBGcfD+Sp2pAKq0ytz8j+1NehvgIGFkvtvFrDM3T8E4x/JJODXK9WZow8RRGrbA9QQ3hs+pDhA== }
@@ -45397,6 +45490,32 @@ packages:
     resolution:
       { integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ== }
     engines: { node: ">=6" }
+    dev: true
+
+  /pac-proxy-agent@7.0.1:
+    resolution:
+      { integrity: sha512-ASV8yU4LLKBAjqIPMbrgtaKIvxQri/yh2OpI+S6hVa9JRkUI3Y3NPFbfngDtY7oFtSMD3w31Xns89mDa3Feo5A== }
+    engines: { node: ">= 14" }
+    dependencies:
+      "@tootallnate/quickjs-emscripten": 0.23.0
+      agent-base: 7.1.0
+      debug: 4.3.4
+      get-uri: 6.0.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.4
+      pac-resolver: 7.0.1
+      socks-proxy-agent: 8.0.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /pac-resolver@7.0.1:
+    resolution:
+      { integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg== }
+    engines: { node: ">= 14" }
+    dependencies:
+      degenerator: 5.0.1
+      netmask: 2.0.2
     dev: true
 
   /pacote@13.6.2:
@@ -47079,6 +47198,23 @@ packages:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  /proxy-agent@6.4.0:
+    resolution:
+      { integrity: sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ== }
+    engines: { node: ">= 14" }
+    dependencies:
+      agent-base: 7.1.0
+      debug: 4.3.4
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.4
+      lru-cache: 7.18.3
+      pac-proxy-agent: 7.0.1
+      proxy-from-env: 1.1.0
+      socks-proxy-agent: 8.0.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /proxy-from-env@1.0.0:
     resolution:
@@ -50035,6 +50171,18 @@ packages:
       - supports-color
     dev: true
 
+  /socks-proxy-agent@8.0.3:
+    resolution:
+      { integrity: sha512-VNegTZKhuGq5vSD6XNKlbqWhyt/40CgoEw8XxD6dhnm8Jq9IEa3nIa4HwnM8XOqU0CdB0BwWVXusqiFXfHB3+A== }
+    engines: { node: ">= 14" }
+    dependencies:
+      agent-base: 7.1.1
+      debug: 4.3.4
+      socks: 2.7.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /socks@2.6.1:
     resolution:
       { integrity: sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA== }
@@ -50149,6 +50297,7 @@ packages:
     resolution:
       { integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g== }
     engines: { node: ">=0.10.0" }
+    requiresBuild: true
     dev: true
 
   /source-map@0.7.4:


### PR DESCRIPTION
**Fixes:** https://github.com/apache/incubator-kie-issues/issues/1207

**Description:**
Executing pnpm bootstrap -F @kie-tools/sonataflow-quarkus-devui... with a proxy we had the error:

[INFO] .../serverless-workflow-diagram-editor install: FetchError: request to https://repo1.maven.org/maven2/org/webjars/animate.css/3.5.2/animate.css-3.5.2.jar failed, reason: connect ECONNREFUSED
