### PR TITLE
[SRVLOGIC-325] use KogitoVersion variable for org.apache.kie.sonataflow:sonataflow-quarkus-devui version 

### DIFF
--- a/packages/kn-plugin-workflow/pkg/metadata/constants.go
+++ b/packages/kn-plugin-workflow/pkg/metadata/constants.go
@@ -41,7 +41,7 @@ var KogitoBomDependency = Dependency{
 var KogitoDependencies = []Dependency{
 	{GroupId: "org.kie", ArtifactId: "kie-addons-quarkus-knative-eventing"},
 	{GroupId: "org.kie", ArtifactId: "kie-addons-quarkus-source-files"},
-	{GroupId: "org.apache.kie.sonataflow", ArtifactId: "sonataflow-quarkus-devui", Version: PluginVersion},
+	{GroupId: "org.apache.kie.sonataflow", ArtifactId: "sonataflow-quarkus-devui", Version: KogitoVersion},
 	{GroupId: "org.kie", ArtifactId: "kogito-addons-quarkus-data-index-inmemory"},
 	{GroupId: "org.apache.kie.sonataflow", ArtifactId: "sonataflow-quarkus"},
 }


### PR DESCRIPTION
cherry-pick of https://github.com/kiegroup/kie-tools/pull/28 to midstream main branch