### PR TITLE
[9.101.x-prod] drop reproducible-build profile from maven-base

### DIFF
--- a/packages/maven-base/pom.xml
+++ b/packages/maven-base/pom.xml
@@ -226,45 +226,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>reproducible-build</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-        <property>
-          <name>reproducible</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-artifact-plugin</artifactId>
-            <configuration />
-            <executions>
-              <execution>
-                <id>check-buildplan</id>
-                <goals>
-                  <goal>check-buildplan</goal>
-                </goals>
-                <!-- The execution's configuration is part of the pluginManagement. This piece here only makes sure the
-                     execution is enabled (by specifying a phase) for full profile builds. -->
-                <phase>validate</phase>
-              </execution>
-              <execution>
-                <id>compare</id>
-                <goals>
-                  <goal>compare</goal>
-                </goals>
-                <!-- The execution's configuration is part of the pluginManagement. This piece here only makes sure the
-                     execution is enabled (by specifying a phase) for full profile builds. -->
-                <phase>install</phase>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>


### PR DESCRIPTION
This is making the build to fail on PNC and it is not really needed for productized build