### PR TITLE
[9.101.x-prod] Fix relative path to operator module

### DIFF
--- a/packages/kn-plugin-workflow/go.mod
+++ b/packages/kn-plugin-workflow/go.mod
@@ -4,9 +4,9 @@ go 1.21
 
 toolchain go1.21.6
 
-replace github.com/apache/incubator-kie-tools/packages/sonataflow-operator/api v0.0.0 => ./node_modules/@kie-tools/sonataflow-operator/api
+replace github.com/apache/incubator-kie-tools/packages/sonataflow-operator/api v0.0.0 => ../sonataflow-operator/api
 
-replace github.com/apache/incubator-kie-tools/packages/sonataflow-operator/workflowproj v0.0.0 => ./node_modules/@kie-tools/sonataflow-operator/workflowproj
+replace github.com/apache/incubator-kie-tools/packages/sonataflow-operator/workflowproj v0.0.0 => ../sonataflow-operator/workflowproj
 
 require (
 	github.com/apache/incubator-kie-tools/packages/sonataflow-operator/api v0.0.0


### PR DESCRIPTION
In other to properly build plugin locally. Otherwise the path is not relative to the current repo layout.

Without the fix:
```
 make build-linux-amd64                                                         
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X github.com/apache/incubator-kie-tools/packages/kn-plugin-workflow/pkg/metadata.QuarkusPlatformGroupId= -X github.com/apache/incubator-kie-tools/packages/kn-plugin-workflow/pkg/metadata.QuarkusVersion= -X github.com/apache/incubator-kie-tools/packages/kn-plugin-workflow/pkg/metadata.PluginVersion= -X github.com/apache/incubator-kie-tools/packages/kn-plugin-workflow/pkg/metadata.DevModeImage= -X github.com/apache/incubator-kie-tools/packages/kn-plugin-workflow/pkg/metadata.KogitoVersion=" -o ./dist/kn-workflow-linux-amd64 cmd/main.go
pkg/command/deploy_undeploy_common.go:29:2: github.com/apache/incubator-kie-tools/packages/sonataflow-operator/api@v0.0.0: replacement directory ./node_modules/@kie-tools/sonataflow-operator/api does not exist
pkg/command/deploy_undeploy_common.go:30:2: github.com/apache/incubator-kie-tools/packages/sonataflow-operator/workflowproj@v0.0.0: replacement directory ./node_modules/@kie-tools/sonataflow-operator/workflowproj does not exist
make: *** [Makefile:57: build-linux-amd64] Error 1
```