### PR TITLE
SRVLOGIC-382: SonataFlow Management Console productization setup in midstream - 2

### DIFF
--- a/packages/pom.xml
+++ b/packages/pom.xml
@@ -18,6 +18,6 @@
 
   <modules>
     <module>sonataflow-quarkus-devui</module>
-    <module>sonataflow-management-console-webapp</module>
+    <module>sonataflow-management-console-image</module>
   </modules>
 </project>

--- a/packages/sonataflow-management-console-image/pom.xml
+++ b/packages/sonataflow-management-console-image/pom.xml
@@ -32,15 +32,15 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.apache.kie.sonataflow</groupId>
-  <artifactId>sonataflow-management-console-webapp</artifactId>
+  <artifactId>sonataflow-management-console-image</artifactId>
 
-  <name>KIE Tools :: SonataFlow Management Console Webapp</name>
+  <name>KIE Tools :: SonataFlow Management Console Image</name>
 
   <packaging>pom</packaging>
 
   <properties>
     <project.build.outputTimestamp>2024-01-12T00:00:00Z</project.build.outputTimestamp>
-    <java.module.name>org.kie.sonataflow.management.console.webapp</java.module.name>
+    <java.module.name>org.kie.sonataflow.management.console.image</java.module.name>
   </properties>
 
   <build>
@@ -62,7 +62,7 @@
               <skip>${skip.ui.build}</skip>
               <pnpmInheritsProxyConfigFromMaven>false</pnpmInheritsProxyConfigFromMaven>
               <arguments
-              >-F sonataflow-management-console-webapp... -F !@kie-tools/dmn-marshaller-backend-compatibility-tester -F !@kie-tools/dmn-testing-models build:prod</arguments>
+              >-F sonataflow-management-console-image... -F !@kie-tools/dmn-marshaller-backend-compatibility-tester -F !@kie-tools/dmn-testing-models build:prod</arguments>
               <environmentVariables>
                 <KIE_TOOLS_BUILD__runTests>false</KIE_TOOLS_BUILD__runTests>
                 <KIE_TOOLS_BUILD__runIntegrationTests>false</KIE_TOOLS_BUILD__runIntegrationTests>

--- a/packages/sonataflow-management-console-image/src/assembly/image-build-zip.xml
+++ b/packages/sonataflow-management-console-image/src/assembly/image-build-zip.xml
@@ -30,10 +30,18 @@
   <includeBaseDirectory>false</includeBaseDirectory>
   <fileSets>
     <fileSet>
-      <directory>dist</directory>
-      <outputDirectory>/</outputDirectory>
+      <directory>dist-dev/sonataflow-management-console-webapp</directory>
+      <outputDirectory>/app</outputDirectory>
       <includes>
         <include>**/*</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>dist-dev</directory>
+      <outputDirectory>/</outputDirectory>
+      <includes>
+        <include>image-env-to-json-standalone</include>
+        <include>EnvJson.schema.json</include>
       </includes>
     </fileSet>
   </fileSets>

--- a/pom.xml
+++ b/pom.xml
@@ -185,14 +185,14 @@
             </configuration>
           </execution>
           <execution>
-            <id>pnpm bootstrap sonataflow-quarkus-devui sonataflow-management-console-webapp</id>
+            <id>pnpm bootstrap sonataflow-quarkus-devui sonataflow-management-console-image</id>
             <goals>
               <goal>pnpm</goal>
             </goals>
             <configuration>
               <skip>${skip.ui.deps}</skip>
               <arguments
-              >bootstrap -F @kie-tools/sonataflow-quarkus-devui... -F @kie-tools/sonataflow-management-console-webapp...</arguments>
+              >bootstrap -F @kie-tools/sonataflow-quarkus-devui... -F @kie-tools/sonataflow-management-console-image...</arguments>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Add `image-env-to-json-standalone` and `EnvJson.schema.json` to `sonataflow-management-console-image-999-SNAPSHOT-image-build.zip`

**Notes:**
@ricardozanini 
- Because I needed the image-env-to-json dependency and the `sonataflow-management-console-image/dist-dev`, I moved the location for this configuration from `sonataflow-management-console-webapp` to `sonataflow-management-console-image`.
- the new zip location is `packages/sonataflow-management-console-image/target/sonataflow-management-console-image-999-SNAPSHOT-image-build.zip`