### PR TITLE
[9.102.x-prod] BAQE-2994: Override drools-bom version as it does not match the kogito version in prod build

### DIFF
--- a/packages/maven-base/pom.xml
+++ b/packages/maven-base/pom.xml
@@ -171,7 +171,7 @@
       <dependency>
         <groupId>org.drools</groupId>
         <artifactId>drools-bom</artifactId>
-        <version>${version.org.kie.kogito}</version>
+        <version>9.102.redhat-00004</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/BAQE-2994

Goal is to allow bootstraping the test suite without the need to do shell workaround and modification on QE side.