### PR TITLE
[9.102.x-prod] SRVLOGIC-480: [CLI] Help text of gen-manifest has typo in --custom-ge…

### DIFF
--- a/packages/kn-plugin-workflow/pkg/command/gen_manifest.go
+++ b/packages/kn-plugin-workflow/pkg/command/gen_manifest.go
@@ -52,7 +52,7 @@ func NewGenManifest() *cobra.Command {
 	{{.Name}} gen-manifest --skip-namespace
 
 	# Persist the generated Operator manifests on a specific custom path
-	{{.Name}} gen-manifest --custom-generated-manifest-dir=<full_directory_path>
+	{{.Name}} gen-manifest --custom-generated-manifests-dir=<full_directory_path>
 
 	# Specify a custom subflows files directory. (default: ./subflows)
 	{{.Name}} gen-manifest --subflows-dir=<full_directory_path>


### PR DESCRIPTION
…nerated-manifests-dir parameter example

https://issues.redhat.com/browse/SRVLOGIC-480