### PR TITLE
SRVLOGIC-429: adjust kogito-db-migrator-tool to build as part of midstream

### DIFF
--- a/packages/kogito-db-migrator-tool/pom.xml
+++ b/packages/kogito-db-migrator-tool/pom.xml
@@ -23,10 +23,10 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 >
   <parent>
-    <groupId>org.kie</groupId>
-    <artifactId>kie-tools-maven-base</artifactId>
-    <version>${revision}</version>
-    <relativePath>./node_modules/@kie-tools/maven-base/pom.xml</relativePath>
+    <groupId>org.apache.kie.sonataflow</groupId>
+    <artifactId>kie-tools-packages</artifactId>
+    <version>999-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
@@ -66,24 +66,32 @@
   <build>
     <testSourceDirectory>src/test/java</testSourceDirectory>
     <plugins>
-      <!-- Use mvn dependency:unpack command to unzip ddl files and mvn dependency:copy to copy into destination -->
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <configuration>
-          <artifactItems>
-            <artifactItem>
-              <groupId>org.kie.kogito</groupId>
-              <artifactId>kogito-ddl</artifactId>
-              <version>${version.org.kie.kogito}</version>
-              <classifier>db-scripts</classifier>
-              <type>zip</type>
-              <overWrite>true</overWrite>
-              <outputDirectory>src/main/resources</outputDirectory>
-              <destFileName>kogito-ddl-db-scripts.zip</destFileName>
-              <excludes>ansi/*</excludes>
-            </artifactItem>
-          </artifactItems>
-        </configuration>
+        <executions>
+          <execution>
+            <id>unpack</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.kie.kogito</groupId>
+                  <artifactId>kogito-ddl</artifactId>
+                  <version>${version.org.kie.kogito}</version>
+                  <classifier>db-scripts</classifier>
+                  <type>zip</type>
+                  <overWrite>true</overWrite>
+                  <outputDirectory>src/main/resources</outputDirectory>
+                  <destFileName>kogito-ddl-db-scripts.zip</destFileName>
+                  <excludes>ansi/*</excludes>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
@@ -117,6 +125,24 @@
             <phase>prepare-package</phase>
             <goals>
               <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.3.0</version>
+        <configuration>
+          <descriptors>
+            <descriptor>src/assembly/image-build-zip.xml</descriptor>
+          </descriptors>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
             </goals>
           </execution>
         </executions>

--- a/packages/kogito-db-migrator-tool/src/assembly/image-build-zip.xml
+++ b/packages/kogito-db-migrator-tool/src/assembly/image-build-zip.xml
@@ -1,0 +1,37 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<assembly
+  xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd"
+>
+  <id>image-build</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>target/quarkus-app</directory>
+      <outputDirectory />
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/packages/pom.xml
+++ b/packages/pom.xml
@@ -19,5 +19,6 @@
   <modules>
     <module>sonataflow-quarkus-devui</module>
     <module>sonataflow-management-console-webapp</module>
+    <module>kogito-db-migrator-tool</module>
   </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <version.npm>6.10.3</version.npm>
     <version.pnpm>9.3.0</version.pnpm>
 
-    <version.quarkus>3.8.6</version.quarkus>
+    <version.quarkus>3.15.3</version.quarkus>
     <version.org.kie.kogito>999-SNAPSHOT</version.org.kie.kogito>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
     <version.maven.artifact.plugin>3.4.1</version.maven.artifact.plugin>
     <compiler-plugin.version>3.13.0</compiler-plugin.version>
     <version.resources.plugin>3.2.0</version.resources.plugin>
+    <version.jacoco.maven.plugin>0.8.12</version.jacoco.maven.plugin>
 
     <version.frontend.plugin>1.15.0</version.frontend.plugin>
     <version.node>v20.15.0</version.node>
@@ -93,6 +94,11 @@
   <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-maven-plugin</artifactId>
+          <version>${version.quarkus}</version>
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-artifact-plugin</artifactId>
@@ -192,7 +198,7 @@
             <configuration>
               <skip>${skip.ui.deps}</skip>
               <arguments
-              >bootstrap -F @kie-tools/sonataflow-quarkus-devui... -F @kie-tools/sonataflow-management-console-webapp...</arguments>
+              >bootstrap -F @kie-tools/sonataflow-quarkus-devui... -F @kie-tools/sonataflow-management-console-webapp... -F @kie-tools/kogito-db-migrator-tool...</arguments>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/SRVLOGIC-429

Adjust kogito-db-migrator-tool to be able to build the quarkus-app on PNC build system and to be consumed for the db-migrator productized image.