### PR TITLE
[9.103.x-prod] Aling maven deploy plugin to major version 3.x

### DIFF
--- a/packages/serverless-workflow-diagram-editor/appformer-bom/pom.xml
+++ b/packages/serverless-workflow-diagram-editor/appformer-bom/pom.xml
@@ -60,7 +60,7 @@
   <properties>
     <sonar.skip>true</sonar.skip>
     <version.j2cl.tools>0.4</version.j2cl.tools>
-    <version.deploy.plugin>2.8.2</version.deploy.plugin>
+    <version.deploy.plugin>3.1.2</version.deploy.plugin>
   </properties>
 
   <dependencyManagement>

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-bom/pom.xml
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-bom/pom.xml
@@ -60,7 +60,7 @@
   <properties>
     <sonar.skip>true</sonar.skip>
     <j2cl.tools.version>0.4</j2cl.tools.version>
-    <version.deploy.plugin>2.8.2</version.deploy.plugin>
+    <version.deploy.plugin>3.1.2</version.deploy.plugin>
   </properties>
 
   <dependencyManagement>

--- a/packages/sonataflow-deployment-webapp/pom.xml
+++ b/packages/sonataflow-deployment-webapp/pom.xml
@@ -48,7 +48,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.deploy.plugin>2.8.2</version.deploy.plugin>
+    <version.deploy.plugin>3.1.2</version.deploy.plugin>
   </properties>
 
   <dependencies />


### PR DESCRIPTION
Some build systems may fail when building kie-tools, as in some places there are usage of maven deploy plugin 2.x where in other places usage of 3.x. Hence, this commit align them all to major version 3.x.