### PR TITLE
[NO-ISSUE] Add ci_build_midstream GHA

### DIFF
--- a/.github/workflows/ci_build_midstream.yml
+++ b/.github/workflows/ci_build_midstream.yml
@@ -1,0 +1,49 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Build Midstream KIE Tools
+
+on:
+  pull_request:
+    branches: ["**"]
+    types: [opened, reopened, ready_for_review, synchronize]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+
+      - name: "Setup environment"
+        uses: apache/incubator-kie-tools/.github/actions/setup-env@main
+
+      - name: Build KIE Tools
+        run: mvn clean install
+
+      # This step works well but can consume midstream storage
+      # - name: Upload JAR artifacts
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: kie-tools-artifacts
+      #     path: |
+      #       packages/sonataflow-quarkus-devui/sonataflow-quarkus-devui/target/sonataflow-quarkus-devui-999-SNAPSHOT.jar
+      #       packages/sonataflow-quarkus-devui/sonataflow-quarkus-devui-deployment/target/sonataflow-quarkus-devui-deployment-999-SNAPSHOT.jar
+      #       packages/sonataflow-management-console-webapp/target/sonataflow-management-console-webapp-999-SNAPSHOT-image-build.zip


### PR DESCRIPTION
This PR brings the midstream build CI check, previously running in my personal [fork](https://github.com/fantonangeli/kie-tools-fantonangeli-ghas/actions/workflows/build_midstream.yml), which has now reached its usage limit, into the official midstream repository.
There is a commented-out section for uploading JAR artifacts. It was working correctly and can be uncommented if we decide to enable artifact downloads from workflow runs for future debugging or usage.

This CI has been tested [here](https://github.com/fantonangeli/kie-tools/actions/runs/15108146740/job/42461250713)