### PR TITLE
[7.67.x-blue] Upgrade netty-handler version to 4.1.118.Final

### DIFF
--- a/packages/dashbuilder/pom.xml
+++ b/packages/dashbuilder/pom.xml
@@ -80,7 +80,7 @@
     <version.org.apache.poi>4.1.2</version.org.apache.poi>
     <version.org.owasp.encoder>1.2</version.org.owasp.encoder>
     <version.org.jboss.xnio>3.8.14.Final</version.org.jboss.xnio>
-    <version.io.netty>4.1.59.Final</version.io.netty>
+    <version.io.netty>4.1.118.Final</version.io.netty>
     <version.com.google.elemental2>1.1.0</version.com.google.elemental2>
     <version.com.allen-sauer.gwt.dnd>3.3.3</version.com.allen-sauer.gwt.dnd>
     <version.org.freemarker>2.3.32</version.org.freemarker>


### PR DESCRIPTION
Updating netty-handler to version 4.1.118.Final resolves the [https://github.com/advisories/GHSA-4g8c-wm8x-jfhw]